### PR TITLE
Reset graphics cannot send 0 monitors, fixes Microsoft App Store clients with avc:420 H264 mode

### DIFF
--- a/xrdp/xrdp_egfx.c
+++ b/xrdp/xrdp_egfx.c
@@ -562,14 +562,26 @@ xrdp_egfx_send_reset_graphics(struct xrdp_egfx *egfx, int width, int height,
     out_uint32_le(s, 340);
     out_uint32_le(s, width);
     out_uint32_le(s, height);
-    out_uint32_le(s, monitor_count);
-    for (index = 0; index < monitor_count; index++)
+    out_uint32_le(s, monitor_count == 0 ? 1 : monitor_count);
+    if (monitor_count == 0)
     {
-        out_uint32_le(s, mi[index].left);
-        out_uint32_le(s, mi[index].top);
-        out_uint32_le(s, mi[index].right);
-        out_uint32_le(s, mi[index].bottom);
-        out_uint32_le(s, mi[index].is_primary);
+        out_uint32_le(s, 0);
+        out_uint32_le(s, 0);
+        out_uint32_le(s, width);
+        out_uint32_le(s, height);
+        out_uint32_le(s, 1);
+        monitor_count = 1;
+    }
+    else
+    {
+        for (index = 0; index < monitor_count; ++index)
+        {
+            out_uint32_le(s, mi[index].left);
+            out_uint32_le(s, mi[index].top);
+            out_uint32_le(s, mi[index].right);
+            out_uint32_le(s, mi[index].bottom);
+            out_uint32_le(s, mi[index].is_primary);
+        }
     }
     if (monitor_count < 16)
     {


### PR DESCRIPTION
When testing this with the Microsoft Remote Desktop (app store clients) this fixes the ability of the graphics transmission to work at all.

It wasn't an error in the capabilities of the clients, it's that there is a difference between the protocol and the implementation that Microsoft has released in their remote desktop clients.

This may not be the "proper" fix, but it prevents the clients from crashing and having a non-functional black screen.

We should file a bug with Microsoft on this, as well.