### PR TITLE
[WIP] Adding dynamic resize to egfx_helper.

### DIFF
--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -14,6 +14,7 @@ include_HEADERS = \
   ms-rdpegdi.h \
   ms-rdpele.h \
   ms-rdperp.h \
+  ms-rdpedisp.h \
   ms-smb2.h \
   xrdp_client_info.h \
   xrdp_constants.h \

--- a/common/ms-rdpedisp.h
+++ b/common/ms-rdpedisp.h
@@ -1,0 +1,29 @@
+/**
+ * xrdp: A Remote Desktop Protocol server.
+ *
+ * MS-RDPEDISP : Definitions from [MS-RDPEDISP]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * References to MS-RDPEDISP are currently correct for v20201030 of that
+ * document
+ */
+
+#if !defined(MS_RDPEDISP_H)
+#define MS_RDPEDISP_H
+
+/* Display Control Messages: Display Virtual Channel Extension (2.2.2) */
+#define DISPLAYCONTROL_PDU_TYPE_MONITOR_LAYOUT 0x00000002
+#define DISPLAYCONTROL_PDU_TYPE_CAPS           0x00000005
+
+#endif /* MS_RDPEDISP_H */

--- a/common/xrdp_client_info.h
+++ b/common/xrdp_client_info.h
@@ -23,13 +23,37 @@
 #if !defined(XRDP_CLIENT_INFO_H)
 #define XRDP_CLIENT_INFO_H
 
+#define XRDP_MAXIMUM_MONITORS 16
+
+/*
+ * 2.2.1.3.6.1 Monitor Definition (TS_MONITOR_DEF)
+ * 2.2.1.3.9.1 Monitor Attributes (TS_MONITOR_ATTRIBUTES)
+ */
+
 struct monitor_info
 {
   int left;
   int top;
+  int width;
+  int height;
   int right;
   int bottom;
+  int physical_width;
+  int physical_height;
+  int orientation;
+  int desktop_scale_factor;
+  int device_scale_factor;
   int is_primary;
+  int flags;
+};
+
+struct display_size_description
+{
+  int monitorCount; /* number of monitors detected (max = 16) */
+  struct monitor_info minfo[XRDP_MAXIMUM_MONITORS]; /* client monitor data */
+  struct monitor_info minfo_wm[XRDP_MAXIMUM_MONITORS]; /* client monitor data, non-negative values */
+  int session_width;
+  int session_height;
 };
 
 struct xrdp_client_info
@@ -111,8 +135,8 @@ struct xrdp_client_info
   int security_layer; /* 0 = rdp, 1 = tls , 2 = hybrid */
   int multimon; /* 0 = deny , 1 = allow */
   int monitorCount; /* number of monitors detected (max = 16) */
-  struct monitor_info minfo[16]; /* client monitor data */
-  struct monitor_info minfo_wm[16]; /* client monitor data, non-negative values */
+  struct monitor_info minfo[XRDP_MAXIMUM_MONITORS]; /* client monitor data */
+  struct monitor_info minfo_wm[XRDP_MAXIMUM_MONITORS]; /* client monitor data, non-negative values */
 
   int keyboard_type;
   int keyboard_subtype;

--- a/libxrdp/xrdp_sec.c
+++ b/libxrdp/xrdp_sec.c
@@ -1903,131 +1903,190 @@ xrdp_sec_process_mcs_data_channels(struct xrdp_sec *self, struct stream *s)
     return 0;
 }
 
-/*****************************************************************************/
-/* reads the client monitors data */
-static int
-xrdp_sec_process_mcs_data_monitors(struct xrdp_sec *self, struct stream *s)
-{
-    int index;
-    int monitorCount;
-    int flags;
-    int x1;
-    int y1;
-    int x2;
-    int y2;
-    int got_primary;
-    struct xrdp_client_info *client_info = (struct xrdp_client_info *)NULL;
+struct display_size_description*
+process_monitor_stream(struct stream *s, int full_parameters) {
+    struct display_size_description *description = (struct display_size_description *)
+        g_malloc(sizeof(struct display_size_description), 1);
 
-    client_info = &(self->rdp_layer->client_info);
+    int NumMonitor;
+    struct monitor_info *monitor_layout;
+    struct xrdp_rect rect = {8192, 8192, -8192, -8192};
 
-    LLOGLN(10, ("xrdp_sec_process_mcs_data_monitors: processing monitors data, allow_multimon is %d", client_info->multimon));
-    /* this is an option set in xrdp.ini */
-    if (client_info->multimon != 1) /* are multi-monitors allowed ? */
+    in_uint32_le(s, NumMonitor);
+    LLOGLN(10, ("  NumMonitor %d", NumMonitor));
+
+    if (NumMonitor >= XRDP_MAXIMUM_MONITORS)
     {
-        LLOGLN(0, ("[INFO] xrdp_sec_process_mcs_data_monitors: multimon is not "
-               "allowed, skipping"));
-        return 0;
-    }
-    in_uint32_le(s, flags); /* flags */
-    //verify flags - must be 0x0
-    if (flags != 0)
-    {
-        LLOGLN(0, ("[ERROR] xrdp_sec_process_mcs_data_monitors: flags MUST be "
-               "zero, detected: %d", flags));
-        return 1;
-    }
-    in_uint32_le(s, monitorCount);
-    //verify monitorCount - max 16
-    if (monitorCount > 16)
-    {
-        LLOGLN(0, ("[ERROR] xrdp_sec_process_mcs_data_monitors: max allowed "
-               "monitors is 16, detected: %d", monitorCount));
-        return 1;
+        LLOGLN(10, (
+            "[MS-RDPBCGR] Protocol error: TS_UD_CS_MONITOR monitorCount "
+            "MUST be less than 16, received: %d", NumMonitor));
+        goto exit_error;
     }
 
-    LLOGLN(10, ("xrdp_sec_process_mcs_data_monitors: monitorCount= %d", monitorCount));
+    description->monitorCount = NumMonitor;
 
-    client_info->monitorCount = monitorCount;
+    int got_primary = 0;
 
-    x1 = 0;
-    y1 = 0;
-    x2 = 0;
-    y2 = 0;
-    got_primary = 0;
-    /* Add client_monitor_data to client_info struct, will later pass to X11rdp */
-    for (index = 0; index < monitorCount; index++)
+    for (int monitor_index = 0; monitor_index < NumMonitor; ++monitor_index)
     {
-        in_uint32_le(s, client_info->minfo[index].left);
-        in_uint32_le(s, client_info->minfo[index].top);
-        in_uint32_le(s, client_info->minfo[index].right);
-        in_uint32_le(s, client_info->minfo[index].bottom);
-        in_uint32_le(s, client_info->minfo[index].is_primary);
-        if (index == 0)
+        if (!s_check_rem(s, full_parameters == 0 ? 20 : 40))
         {
-            x1 = client_info->minfo[index].left;
-            y1 = client_info->minfo[index].top;
-            x2 = client_info->minfo[index].right;
-            y2 = client_info->minfo[index].bottom;
+            goto exit_error;
+        }
+
+        monitor_layout = description->minfo + monitor_index;
+        if (full_parameters != 0) {
+            in_uint32_le(s, monitor_layout->flags);
+        }
+        in_uint32_le(s, monitor_layout->left);
+        in_uint32_le(s, monitor_layout->top);
+        in_uint32_le(s, monitor_layout->width);
+        in_uint32_le(s, monitor_layout->height);
+        if (full_parameters != 0) {
+            in_uint32_le(s, monitor_layout->physical_width);
+            in_uint32_le(s, monitor_layout->physical_height);
+            in_uint32_le(s, monitor_layout->orientation);
+            in_uint32_le(s, monitor_layout->desktop_scale_factor);
+            in_uint32_le(s, monitor_layout->device_scale_factor);
+        }
+
+        monitor_layout->right = monitor_layout->left + monitor_layout->width;
+        monitor_layout->bottom = monitor_layout->top + monitor_layout->height;
+
+        if (full_parameters != 0)
+        {
+            LLOGLN(10, ("    Index: %d, Flags 0x%8.8x Left %d Top %d "
+                "Width %d Height %d PhysicalWidth %d PhysicalHeight %d "
+                "Orientation %d DesktopScaleFactor %d DeviceScaleFactor %d",
+                monitor_index, monitor_layout->flags, monitor_layout->left,
+                monitor_layout->top, monitor_layout->width, monitor_layout->height,
+                monitor_layout->physical_width, monitor_layout->physical_height,
+                monitor_layout->orientation, monitor_layout->desktop_scale_factor,
+                monitor_layout->device_scale_factor));
         }
         else
         {
-            x1 = MIN(x1, client_info->minfo[index].left);
-            y1 = MIN(y1, client_info->minfo[index].top);
-            x2 = MAX(x2, client_info->minfo[index].right);
-            y2 = MAX(y2, client_info->minfo[index].bottom);
+            LLOGLN(10, ("Received [MS-RDPBCGR] "
+                "TS_UD_CS_MONITOR.TS_MONITOR_DEF %d "
+                "left %d, top %d, right %d, bottom %d, flags 0x%8.8x",
+                monitor_index,
+                monitor_layout->left,
+                monitor_layout->top,
+                monitor_layout->right,
+                monitor_layout->bottom,
+                monitor_layout->is_primary));
         }
 
-        if (client_info->minfo[index].is_primary)
+        if (monitor_index == 0)
+        {
+            rect.left = monitor_layout->left;
+            rect.top = monitor_layout->top;
+            rect.right = monitor_layout->right;
+            rect.bottom = monitor_layout->bottom;
+        }
+        else
+        {
+            rect.left = MIN(monitor_layout->left, rect.left);
+            rect.top = MIN(monitor_layout->top, rect.top);
+            rect.right = MAX(rect.right, monitor_layout->right);
+            rect.bottom = MAX(rect.bottom, monitor_layout->bottom);
+        }
+
+        if (monitor_layout->is_primary)
         {
             got_primary = 1;
         }
-
-        LLOGLN(10, ("xrdp_sec_process_mcs_data_monitors: got a monitor [%d]: left= %d, top= %d, right= %d, bottom= %d, is_primary?= %d",
-                index,
-                client_info->minfo[index].left,
-                client_info->minfo[index].top,
-                client_info->minfo[index].right,
-                client_info->minfo[index].bottom,
-                client_info->minfo[index].is_primary));
     }
 
     if (!got_primary)
     {
         /* no primary monitor was set, choose the leftmost monitor as primary */
-        for (index = 0; index < monitorCount; index++)
+        for (int monitor_index = 0; monitor_index < NumMonitor; ++monitor_index)
         {
-            if (client_info->minfo[index].left == x1 &&
-                    client_info->minfo[index].top == y1)
+            monitor_layout = description->minfo + monitor_index;
+            if (monitor_layout->left != rect.left || monitor_layout->top != rect.top)
             {
-                client_info->minfo[index].is_primary = 1;
-                break;
+                continue;
             }
+            monitor_layout->is_primary = 1;
         }
     }
 
     /* set wm geometry */
-    if ((x2 > x1) && (y2 > y1))
+    if ((rect.right > rect.left) && (rect.bottom > rect.top))
     {
-        client_info->width = (x2 - x1) + 1;
-        client_info->height = (y2 - y1) + 1;
+        description->session_width = rect.right - rect.left;
+        description->session_height = rect.bottom - rect.top;
     }
     /* make sure virtual desktop size is ok */
-    if (client_info->width > 0x7FFE || client_info->width < 0xC8 ||
-        client_info->height > 0x7FFE || client_info->height < 0xC8)
+    if (description->session_width > 0x7FFE || description->session_width < 0xC8 ||
+            description->session_height > 0x7FFE || description->session_height < 0xC8)
     {
-        LLOGLN(0, ("[ERROR] xrdp_sec_process_mcs_data_monitors: error, virtual desktop width / height is too large"));
-        return 1; /* error */
+        LLOGLN(0, ("Client supplied virtual desktop width or height is invalid. "
+            "Allowed width range: min %d, max %d. Width received: %d. "
+            "Allowed height range: min %d, max %d. Height received: %d",
+            0xC8, 0x7FFE, description->session_width,
+            0xC8, 0x7FFE, description->session_width));
+        goto exit_error;
     }
 
     /* keep a copy of non negative monitor info values for xrdp_wm usage */
-    for (index = 0; index < monitorCount; index++)
+    for (int monitor_index = 0; monitor_index < NumMonitor; ++monitor_index)
     {
-        client_info->minfo_wm[index].left =  client_info->minfo[index].left - x1;
-        client_info->minfo_wm[index].top =  client_info->minfo[index].top - y1;
-        client_info->minfo_wm[index].right =  client_info->minfo[index].right - x1;
-        client_info->minfo_wm[index].bottom =  client_info->minfo[index].bottom - y1;
-        client_info->minfo_wm[index].is_primary =  client_info->minfo[index].is_primary;
+        monitor_layout = description->minfo_wm + monitor_index;
+
+        g_memcpy(monitor_layout, description->minfo + monitor_index, sizeof(struct monitor_info));
+
+        monitor_layout->left = monitor_layout->left - rect.left;
+        monitor_layout->top = monitor_layout->top - rect.top;
+        monitor_layout->right = monitor_layout->right - rect.left;
+        monitor_layout->bottom = monitor_layout->bottom - rect.top;
     }
+    return description;
+exit_error:
+    g_free(description);
+    return NULL;
+}
+
+/*****************************************************************************/
+/* Process a [MS-RDPBCGR] TS_UD_CS_MONITOR message.
+   reads the client monitors data */
+static int
+xrdp_sec_process_mcs_data_monitors(struct xrdp_sec *self, struct stream *s)
+{
+    int flags;
+    struct xrdp_client_info *client_info = &(self->rdp_layer->client_info);
+
+    /* this is an option set in xrdp.ini */
+    if (client_info->multimon != 1) /* are multi-monitors allowed ? */
+    {
+         LLOGLN(0, ("Multi-monitor is disabled by server config"));
+         return 0;
+    }
+    if (!s_check_rem(s, 8))
+    {
+         return 1;
+    }
+    in_uint32_le(s, flags); /* flags */
+
+    //verify flags - must be 0x0
+    if (flags != 0)
+    {
+        LLOGLN(10, (
+            "[MS-RDPBCGR] Protocol error: TS_UD_CS_MONITOR flags MUST be zero, "
+            "received: 0x%8.8x", flags));
+        return 1;
+    }
+
+    struct display_size_description *description = process_monitor_stream(s, 0);
+
+    client_info->monitorCount = description->monitorCount;
+    client_info->width = description->session_width;
+    client_info->height = description->session_height;
+    g_memcpy(client_info->minfo, description->minfo, sizeof(struct monitor_info) * XRDP_MAXIMUM_MONITORS);
+    g_memcpy(client_info->minfo_wm, description->minfo_wm, sizeof(struct monitor_info) * XRDP_MAXIMUM_MONITORS);
+
+    g_free(description);
 
     return 0;
 }

--- a/xrdp/xrdp_egfx.c
+++ b/xrdp/xrdp_egfx.c
@@ -567,8 +567,8 @@ xrdp_egfx_send_reset_graphics(struct xrdp_egfx *egfx, int width, int height,
     {
         out_uint32_le(s, 0);
         out_uint32_le(s, 0);
-        out_uint32_le(s, width);
-        out_uint32_le(s, height);
+        out_uint32_le(s, width - 1);
+        out_uint32_le(s, height - 1);
         out_uint32_le(s, 1);
         monitor_count = 1;
     }
@@ -864,7 +864,17 @@ xrdp_egfx_create(struct xrdp_mm *mm, struct xrdp_egfx **egfx)
 int
 xrdp_egfx_delete(struct xrdp_egfx *egfx)
 {
-    g_free(egfx);
-    return 0;
-}
+    LLOGLN(0, ("xrdp_egfx_delete:"));
 
+    int error = xrdp_egfx_send_delete_surface(egfx, egfx->surface_id);
+    if (error != 0)
+    {
+        LLOGLN(0, ("dynamic_monitor_data: xrdp_egfx_send_delete_surface failed %d", error));
+        return error;
+    }
+    error = libxrdp_drdynvc_close(egfx->session, egfx->channel_id);
+
+    g_free(egfx);
+
+    return error;
+}

--- a/xrdp/xrdp_types.h
+++ b/xrdp/xrdp_types.h
@@ -50,7 +50,12 @@ struct xrdp_mod
   int (*mod_frame_ack)(struct xrdp_mod* v, int flags, int frame_id);
   int (*mod_suppress_output)(struct xrdp_mod* v, int suppress,
                              int left, int top, int right, int bottom);
-  tintptr mod_dumby[100 - 11]; /* align, 100 minus the number of mod
+  int (*mod_server_monitor_resize)(struct xrdp_mod* v,
+                             int width, int height, int bpp);
+  int (*mod_server_monitor_full_invalidate)(struct xrdp_mod* v,
+                             int width, int height);
+  int (*mod_server_version_message)(struct xrdp_mod* v);
+  tintptr mod_dumby[100 - 14]; /* align, 100 minus the number of mod
                                   functions above */
   /* server functions */
   int (*server_begin_update)(struct xrdp_mod* v);
@@ -299,10 +304,13 @@ struct xrdp_mm
   struct xrdp_encoder *encoder;
   int cs2xr_cid_map[256];
   int xr2cr_cid_map[256];
+  int dynamic_monitor_chanid;
   struct xrdp_egfx *egfx;
   int egfx_up;
   int egfx_flags;
   int gfx_delay_autologin;
+  struct list *resize_queue;
+  int resizing;
 };
 
 struct xrdp_key_info

--- a/xup/xup.c
+++ b/xup/xup.c
@@ -33,6 +33,15 @@
     do { if (_level < LOG_LEVEL) { g_writeln _args ; } } while (0)
 
 static int
+send_server_monitor_resize(struct mod *mod, struct stream *s, int width, int height, int bpp);
+
+static int
+send_server_monitor_full_invalidate(struct mod *mod, struct stream *s, int width, int height);
+
+static int
+send_server_version_message(struct mod *v, struct stream *s);
+
+static int
 lib_mod_process_message(struct mod *mod, struct stream *s);
 
 /******************************************************************************/
@@ -144,7 +153,6 @@ int
 lib_mod_connect(struct mod *mod)
 {
     int error;
-    int len;
     int i;
     int use_uds;
     struct stream *s;
@@ -252,60 +260,17 @@ lib_mod_connect(struct mod *mod)
 
     if (error == 0)
     {
-        /* send version message */
-        init_stream(s, 8192);
-        s_push_layer(s, iso_hdr, 4);
-        out_uint16_le(s, 103);
-        out_uint32_le(s, 301);
-        out_uint32_le(s, 0);
-        out_uint32_le(s, 0);
-        out_uint32_le(s, 0);
-        out_uint32_le(s, 1);
-        s_mark_end(s);
-        len = (int)(s->end - s->data);
-        s_pop_layer(s, iso_hdr);
-        out_uint32_le(s, len);
-        lib_send_copy(mod, s);
+        error = send_server_version_message(mod, s);
     }
 
     if (error == 0)
     {
-        /* send screen size message */
-        init_stream(s, 8192);
-        s_push_layer(s, iso_hdr, 4);
-        out_uint16_le(s, 103);
-        out_uint32_le(s, 300);
-        out_uint32_le(s, mod->width);
-        out_uint32_le(s, mod->height);
-        out_uint32_le(s, mod->bpp);
-        out_uint32_le(s, 0);
-        s_mark_end(s);
-        len = (int)(s->end - s->data);
-        s_pop_layer(s, iso_hdr);
-        out_uint32_le(s, len);
-        lib_send_copy(mod, s);
+        error = send_server_monitor_resize(mod, s, mod->width, mod->height, mod->bpp);
     }
 
     if (error == 0)
     {
-        /* send invalidate message */
-        init_stream(s, 8192);
-        s_push_layer(s, iso_hdr, 4);
-        out_uint16_le(s, 103);
-        out_uint32_le(s, 200);
-        /* x and y */
-        i = 0;
-        out_uint32_le(s, i);
-        /* width and height */
-        i = ((mod->width & 0xffff) << 16) | mod->height;
-        out_uint32_le(s, i);
-        out_uint32_le(s, 0);
-        out_uint32_le(s, 0);
-        s_mark_end(s);
-        len = (int)(s->end - s->data);
-        s_pop_layer(s, iso_hdr);
-        out_uint32_le(s, len);
-        lib_send_copy(mod, s);
+        error = send_server_monitor_full_invalidate(mod, s, mod->width, mod->height);
     }
 
     free_stream(s);
@@ -1305,6 +1270,119 @@ process_server_paint_rect_shmem_ex(struct mod *amod, struct stream *s)
 /******************************************************************************/
 /* return error */
 static int
+send_server_version_message(struct mod *mod, struct stream *s)
+{
+    /* send version message */
+    init_stream(s, 8192);
+    s_push_layer(s, iso_hdr, 4);
+    out_uint16_le(s, 103);
+    out_uint32_le(s, 301);
+    out_uint32_le(s, 0);
+    out_uint32_le(s, 0);
+    out_uint32_le(s, 0);
+    out_uint32_le(s, 1);
+    s_mark_end(s);
+    int len = (int)(s->end - s->data);
+    s_pop_layer(s, iso_hdr);
+    out_uint32_le(s, len);
+    int rv = lib_send_copy(mod, s);
+    return rv;
+}
+
+/******************************************************************************/
+/* return error */
+static int
+send_server_monitor_resize(struct mod *mod, struct stream *s, int width, int height, int bpp)
+{
+    /* send screen size message */
+    init_stream(s, 8192);
+    s_push_layer(s, iso_hdr, 4);
+    out_uint16_le(s, 103);
+    out_uint32_le(s, 300);
+    out_uint32_le(s, width);
+    out_uint32_le(s, height);
+    out_uint32_le(s, bpp);
+    out_uint32_le(s, 0);
+    s_mark_end(s);
+    int len = (int)(s->end - s->data);
+    s_pop_layer(s, iso_hdr);
+    out_uint32_le(s, len);
+    int rv = lib_send_copy(mod, s);
+    LLOGLN(10, ("send_server_monitor_resize: sent resize message with following properties to xorgxrdp backend "
+        "width=%d, height=%d, bpp=%d, return value=%d",
+        width, height, bpp, rv));
+    return rv;
+}
+
+static int
+send_server_monitor_full_invalidate(struct mod *mod, struct stream *s, int width, int height)
+{
+    /* send invalidate message */
+    init_stream(s, 8192);
+    s_push_layer(s, iso_hdr, 4);
+    out_uint16_le(s, 103);
+    out_uint32_le(s, 200);
+    /* x and y */
+    int i = 0;
+    out_uint32_le(s, i);
+    /* width and height */
+    i = ((width & 0xffff) << 16) | height;
+    out_uint32_le(s, i);
+    out_uint32_le(s, 0);
+    out_uint32_le(s, 0);
+    s_mark_end(s);
+    int len = (int)(s->end - s->data);
+    s_pop_layer(s, iso_hdr);
+    out_uint32_le(s, len);
+    int rv = lib_send_copy(mod, s);
+    LLOGLN(10, ("send_server_monitor_full_invalidate: sent invalidate message with following properties to xorgxrdp backend "
+        "width=%d, height=%d, return value=%d",
+        width, height, rv));
+    return rv;
+}
+
+/******************************************************************************/
+/* return error */
+static int
+lib_send_server_version_message(struct mod *mod)
+{
+    /* send server version message */
+    struct stream *s;
+    make_stream(s);
+    int rv = send_server_version_message(mod, s);
+    free_stream(s);
+    return rv;
+}
+
+/******************************************************************************/
+/* return error */
+static int
+lib_send_server_monitor_resize(struct mod *mod, int width, int height, int bpp)
+{
+    /* send screen size message */
+    struct stream *s;
+    make_stream(s);
+    int rv = send_server_monitor_resize(mod, s, width, height, bpp);
+    free_stream(s);
+    return rv;
+}
+
+/******************************************************************************/
+/* return error */
+static int
+lib_send_server_monitor_full_invalidate(struct mod *mod, int width, int height)
+{
+    /* send invalidate message */
+    struct stream *s;
+    make_stream(s);
+    int rv = send_server_monitor_full_invalidate(mod, s, width, height);
+    free_stream(s);
+    return rv;
+}
+
+/******************************************************************************/
+/* return error */
+static int
 lib_mod_process_orders(struct mod *mod, int type, struct stream *s)
 {
     int rv;
@@ -1646,6 +1724,9 @@ mod_init(void)
     mod->mod_check_wait_objs = lib_mod_check_wait_objs;
     mod->mod_frame_ack = lib_mod_frame_ack;
     mod->mod_suppress_output = lib_mod_suppress_output;
+    mod->mod_server_monitor_resize = lib_send_server_monitor_resize;
+    mod->mod_server_monitor_full_invalidate = lib_send_server_monitor_full_invalidate;
+    mod->mod_server_version_message = lib_send_server_version_message;
     return (tintptr) mod;
 }
 

--- a/xup/xup.h
+++ b/xup/xup.h
@@ -48,7 +48,12 @@ struct mod
   int (*mod_frame_ack)(struct mod* v, int flags, int frame_id);
   int (*mod_suppress_output)(struct mod* v, int suppress,
                              int left, int top, int right, int bottom);
-  tintptr mod_dumby[100 - 11]; /* align, 100 minus the number of mod
+  int (*mod_server_monitor_resize)(struct mod* v,
+                             int width, int height, int bpp);
+  int (*mod_server_monitor_full_invalidate)(struct mod* v,
+                             int width, int height);
+  int (*mod_server_version_message)(struct mod* v);
+  tintptr mod_dumby[100 - 14]; /* align, 100 minus the number of mod
                                  functions above */
   /* server functions */
   int (*server_begin_update)(struct mod* v);


### PR DESCRIPTION
This is the best I have right now for adding dynamic resize to the egfx_helper branch, but it's only good for 2-5 resizes before something goes wrong.

It appears to be rock-solid-stable with the original egfx branch, but something about this occasionally causes [this check](https://github.com/jsorg71/xrdp/blob/egfx_helper/xorgxrdp_helper/xorgxrdp_helper.c#L584) to fail (error = trans_check_wait_objs(xi.xrdp_trans);)

Also there seems to be a bug where the latest version of FreeRDP reports this error message:

```
[22:11:01:272] [14562:10563000] [ERROR][com.winpr.thread] - failed to create event
[22:11:01:273] [14562:10563000] [ERROR][com.freerdp.core.codecs] - Failed to create progressive codec context
```

Note that this requires all the of fixes I've submitted to xorgxrdp before this works.