### PR TITLE
Refactor into state machine as well as use the invalidate and resizing messages to stabilize egfx_helper resize-on-the-fly

### DIFF
--- a/common/xrdp_client_info.h
+++ b/common/xrdp_client_info.h
@@ -47,6 +47,49 @@ struct monitor_info
   int flags;
 };
 
+enum display_resize_state {
+  WMRZ_QUEUED = 0,
+  WMRZ_ENCODER_DELETE,
+  WMRZ_EGFX_DELETE_SURFACE,
+  WMRZ_EGFX_CONN_CLOSE,
+  WMRZ_EGFX_CONN_CLOSING,
+  WMRZ_EGFX_CONN_CLOSED,
+  WRMZ_EGFX_DELETE,
+  WMRZ_SERVER_MONITOR_RESIZE,
+  WMRZ_SERVER_VERSION_MESSAGE_START,
+  WMRZ_SERVER_MONITOR_MESSAGE_PROCESSING,
+  WMRZ_SERVER_MONITOR_MESSAGE_PROCESSED,
+  WMRZ_XRDP_CORE_RESIZE,
+  WMRZ_EGFX_INITIALIZE,
+  WMRZ_EGFX_INITALIZING,
+  WMRZ_EGFX_INITIALIZED,
+  WMRZ_SERVER_INVALIDATE,
+  WMRZ_COMPLETE,
+  WMRZ_ERROR
+};
+
+#define XRDP_DISPLAY_RESIZE_STATE_TO_STR(status) \
+  ((status) == WMRZ_QUEUED ? "QUEUED" : \
+   (status) == WMRZ_ENCODER_DELETE ? "ENCODER_DELETE" : \
+   (status) == WMRZ_EGFX_DELETE_SURFACE ? "EGFX_DELETE_SURFACE" : \
+   (status) == WMRZ_EGFX_CONN_CLOSE ? "EGFX_CONN_CLOSE" : \
+   (status) == WMRZ_EGFX_CONN_CLOSING ? "EGFX_CONN_CLOSING" : \
+   (status) == WMRZ_EGFX_CONN_CLOSED ? "EGFX_CONN_CLOSED" : \
+   (status) == WRMZ_EGFX_DELETE ? "EGFX_DELETE" : \
+   (status) == WMRZ_SERVER_MONITOR_RESIZE ? "SERVER_MONITOR_RESIZE" : \
+   (status) == WMRZ_SERVER_VERSION_MESSAGE_START ? "SERVER_VERSION_MESSAGE_START" : \
+   (status) == WMRZ_SERVER_MONITOR_MESSAGE_PROCESSING ? "SERVER_MONITOR_MESSAGE_PROCESSING" : \
+   (status) == WMRZ_SERVER_MONITOR_MESSAGE_PROCESSED ? "SERVER_MONITOR_MESSAGE_PROCESSED" : \
+   (status) == WMRZ_XRDP_CORE_RESIZE ? "XRDP_CORE_RESIZE" : \
+   (status) == WMRZ_EGFX_INITIALIZE ? "EGFX_INITIALIZE" : \
+   (status) == WMRZ_EGFX_INITALIZING ? "EGFX_INITALIZING" : \
+   (status) == WMRZ_EGFX_INITIALIZED ? "EGFX_INITIALIZED" : \
+   (status) == WMRZ_SERVER_INVALIDATE ? "SERVER_INVALIDATE" : \
+   (status) == WMRZ_COMPLETE ? "COMPLETE" : \
+   (status) == WMRZ_ERROR ? "ERROR" : \
+   "unknown" \
+  )
+
 struct display_size_description
 {
   int monitorCount; /* number of monitors detected (max = 16) */
@@ -54,6 +97,9 @@ struct display_size_description
   struct monitor_info minfo_wm[XRDP_MAXIMUM_MONITORS]; /* client monitor data, non-negative values */
   int session_width;
   int session_height;
+  enum display_resize_state state;
+  int last_state_update_timestamp;
+  int start_time;
 };
 
 struct xrdp_client_info

--- a/libxrdp/xrdp_channel.c
+++ b/libxrdp/xrdp_channel.c
@@ -23,6 +23,7 @@
 #endif
 
 #include "libxrdp.h"
+#include "xrdp_channel.h"
 
 /* todo, move these to constants.h */
 //#define CHANNEL_CHUNK_LENGTH 1600 /* todo, why is this so small? */
@@ -36,11 +37,6 @@
 #define CMD_DVC_DATA            0x30
 #define CMD_DVC_CLOSE_CHANNEL   0x40
 #define CMD_DVC_CAPABILITY      0x50
-
-#define XRDP_DRDYNVC_STATUS_CLOSED          0
-#define XRDP_DRDYNVC_STATUS_OPEN_SENT       1
-#define XRDP_DRDYNVC_STATUS_OPEN            2
-#define XRDP_DRDYNVC_STATUS_CLOSE_SENT      3
 
 /*****************************************************************************/
 /* returns pointer or nil on error */

--- a/libxrdp/xrdp_channel.h
+++ b/libxrdp/xrdp_channel.h
@@ -1,0 +1,30 @@
+/**
+ * xrdp: A Remote Desktop Protocol server.
+ *
+ * MS-RDPEDISP : Definitions from [MS-RDPEDISP]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * References to MS-RDPEDISP are currently correct for v20201030 of that
+ * document
+ */
+
+#if !defined(XRDP_CHANNEL_H)
+#define XRDP_CHANNEL_H
+
+#define XRDP_DRDYNVC_STATUS_CLOSED          0
+#define XRDP_DRDYNVC_STATUS_OPEN_SENT       1
+#define XRDP_DRDYNVC_STATUS_OPEN            2
+#define XRDP_DRDYNVC_STATUS_CLOSE_SENT      3
+
+#endif /* XRDP_CHANNEL_H */

--- a/xorgxrdp_helper/xorgxrdp_helper_x11.c
+++ b/xorgxrdp_helper/xorgxrdp_helper_x11.c
@@ -904,7 +904,7 @@ xorgxrdp_helper_x11_get_wait_objs(intptr_t *objs, int *obj_count)
 
 /*****************************************************************************/
 int
-xorgxrdp_helper_x11_check_wai_objs(void)
+xorgxrdp_helper_x11_check_wait_objs(void)
 {
     XEvent xevent;
 

--- a/xorgxrdp_helper/xorgxrdp_helper_x11.h
+++ b/xorgxrdp_helper/xorgxrdp_helper_x11.h
@@ -7,7 +7,7 @@ xorgxrdp_helper_x11_init(void);
 int
 xorgxrdp_helper_x11_get_wait_objs(intptr_t *objs, int *obj_count);
 int
-xorgxrdp_helper_x11_check_wai_objs(void);
+xorgxrdp_helper_x11_check_wait_objs(void);
 int
 xorgxrdp_helper_x11_delete_all_pixmaps(void);
 int

--- a/xrdp/xrdp_egfx.h
+++ b/xrdp/xrdp_egfx.h
@@ -121,11 +121,16 @@ struct xrdp_egfx
     int (*caps_advertise)(void* user, int num_caps, int *version, int *flags);
     int (*frame_ack)(void* user, int queue_depth, int frame_id, int frames_decoded);
 };
-
 int
 xrdp_egfx_create(struct xrdp_mm *mm, struct xrdp_egfx **egfx);
 int
-xrdp_egfx_delete(struct xrdp_egfx *egfx);
+xrdp_egfx_shutdown_delete_surface(struct xrdp_egfx *egfx);
+int
+xrdp_egfx_shutdown_close_connection(struct xrdp_egfx *egfx);
+int
+xrdp_egfx_shutdown_delete(struct xrdp_egfx *egfx);
+int
+xrdp_egfx_shutdown_full(struct xrdp_egfx *egfx);
 int
 xrdp_egfx_send_create_surface(struct xrdp_egfx *egfx, int surface_id,
                               int width, int height, int pixel_format);

--- a/xrdp/xrdp_encoder_nvenc.c
+++ b/xrdp/xrdp_encoder_nvenc.c
@@ -99,7 +99,7 @@ xrdp_encoder_nvenc_create(void)
 
 /*****************************************************************************/
 static int
-xrdp_encoder_cleanup_ncenc_encoder(struct nvenc_global *ng, struct nvenc_encoder *ne)
+xrdp_encoder_cleanup_nvenc_encoder(struct nvenc_global *ng, struct nvenc_encoder *ne)
 {
     int index;
 
@@ -138,7 +138,7 @@ xrdp_encoder_nvenc_delete(void *handle)
     for (index = 0; index < 16; index++)
     {
         ne = ng->encoders + index;
-        xrdp_encoder_cleanup_ncenc_encoder(ng, ne);
+        xrdp_encoder_cleanup_nvenc_encoder(ng, ne);
     }
     for (index = 0; index < ng->cu_dev_count; index++)
     {
@@ -177,7 +177,7 @@ xrdp_encoder_nvenc_encode(void *handle, int session,
     ne = ng->encoders + (session & 0xF);
     if ((ne->enc == NULL) || (ne->width != width) || (ne->height != height))
     {
-        xrdp_encoder_cleanup_ncenc_encoder(ng, ne);
+        xrdp_encoder_cleanup_nvenc_encoder(ng, ne);
         if ((width > 0) && (height > 0))
         {
             g_memset(&params, 0, sizeof(params));

--- a/xrdp/xrdp_types.h
+++ b/xrdp/xrdp_types.h
@@ -310,7 +310,7 @@ struct xrdp_mm
   int egfx_flags;
   int gfx_delay_autologin;
   struct list *resize_queue;
-  int resizing;
+  tbus resize_state_machine;
 };
 
 struct xrdp_key_info

--- a/xup/xup.c
+++ b/xup/xup.c
@@ -1525,6 +1525,12 @@ lib_mod_process_message(struct mod *mod, struct stream *s)
     int type;
     char *phold;
 
+    int width;
+    int height;
+    int magic;
+    int con_id;
+    int mon_id;
+
     LLOGLN(10, ("lib_mod_process_message:"));
     rv = 0;
     if (rv == 0)
@@ -1583,6 +1589,34 @@ lib_mod_process_message(struct mod *mod, struct stream *s)
                     break;
                 }
 
+                s->p = phold + len;
+            }
+        }
+        else if (type == 100) // xorgxrdp_helper commands.
+        {
+            for (index = 0; index < num_orders; index++)
+            {
+                phold = s->p;
+                in_uint16_le(s, type);
+                in_uint16_le(s, len);
+                switch (type)
+                {
+                    case 1: // xorgxrdp_helper_x11_delete_all_pixmaps
+                        // No-op for now.
+                        break;
+                    case 2: // xorgxrdp_helper_x11_create_pixmap
+                        in_uint16_le(s, width);
+                        in_uint16_le(s, height);
+                        in_uint32_le(s, magic);
+                        in_uint32_le(s, con_id);
+                        in_uint32_le(s, mon_id);
+
+                        LLOGLN(10, ("Received xorgxrdp_helper_x11_create_pixmap command. width: %d, height: %d, magic: %d, con_id %d, mon_id %d", 
+                                width, height, magic, con_id, mon_id));
+
+                        mod->server_reset(mod, width, height, 0);
+                        break;
+                }
                 s->p = phold + len;
             }
         }


### PR DESCRIPTION
- Fix potential startup error in the xorgxrdp_helper.
- Refactor into state machine.
- Improve sending the H264 IDR frame after resize by intercepting the
invalidate message that's sent to xorgxrdp.
- Also intercept the resize message
- Careful orchestration of resizing signaling to make sure the keyframe is always delivered properly.